### PR TITLE
Harden storage adapter factories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ In the underlying Flysystem implementation some adapters are more or less comple
 
 ## Support
 
-For bugs and feature requests, please use the [issues](https://github.com/php-collective/file-storage/issues) section of this repository.
+For bugs and feature requests, please use the [issues](https://github.com/php-collective/file-storage-factories/issues) section of this repository.

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "sftp",
         "file"
     ],
-    "homepage": "https://github.com/burzum/storage-factory",
+    "homepage": "https://github.com/php-collective/file-storage-factories",
     "license": "MIT",
     "authors": [
         {

--- a/docs/Factories.md
+++ b/docs/Factories.md
@@ -6,7 +6,7 @@ In the underlying Flysystem implementation some adapters are more or less comple
 
 The factories will always return new instances. Use the `StorageService`, the `AdapterCollection` or your own way of keeping a list of instances.
 
-For now the underlying Flysystem implementation is set to ^1.0 because it simply provides more adapters for now. This might change in a future major release of this library.
+This package targets Flysystem v3.
 
 ## Factories
 
@@ -29,11 +29,13 @@ https://github.com/thephpleague/flysystem-aws-s3-v3
 
 ### Azure
 
-https://github.com/thephpleague/flysystem-azure
+https://github.com/thephpleague/flysystem-azure-blob-storage
 
 **Options**
  * **accountName**: Name of the account
  * **apiKey**: Your API key
+
+This adapter currently depends on the legacy Microsoft Azure SDK through Flysystem's Azure package. If you need a newer Azure integration strategy, consider providing a custom factory.
 
 ### Dropbox
 
@@ -41,19 +43,6 @@ https://github.com/spatie/flysystem-dropbox
 
 **Options**
  * **authToken**: Auth Token
-
-### FtpFactory
-
-**Options**
- * **host**: Host, required
- * **username**: Username, required
- * **password**: Password, required
- * **port**: Port, default 21
- * **root**: Root folder
- * **passive**: Boolean, default true
- * **ssl**: Boolean, default true
- * **timeout**: Timeout in seconds, default 30
- * **ignorePassiveAddress**: Boolean, default false
 
 ### Local
 
@@ -72,41 +61,6 @@ https://flysystem.thephpleague.com/v1/docs/adapter/null-test/
 
 No options
 
-### Rackspace
-
-https://github.com/thephpleague/flysystem-rackspace
-
-**Options**
- * **username**: Required
- * **apiKey**: Required
- * **identityEndpoint**: Default Rackspace::UK_IDENTITY_ENDPOINT
- * **objectStoreService**: Default 'cloudFiles'
- * **serviceRegion**: Default 'LON'
- * **container**: Default 'flysystem'
-
-### Replica
-
-https://github.com/thephpleague/flysystem-replicate-adapter
-
-**Options**:
- * **source** A source adapter instance
- * **target** The adapter to replicate to
-
-### SFTP
-
-https://github.com/thephpleague/flysystem-sftp
-
-**Options**:
- * **host**: Required
- * **port**: Default, 22
- * **username**: Required
- * **password**: Required
- * **privateKey**: Required
- * **passphrase**: Required
- * **root**: Default '/'
- * **timeout**: => Dfault 10
- * **directoryPerm**: => Default 0755
-
 ### WebDAV
 
  * https://github.com/thephpleague/flysystem-webdav
@@ -114,15 +68,19 @@ https://github.com/thephpleague/flysystem-sftp
 
 **Options**:
  * **baseUri**: Required
- * **userName**: Required
- * **password**: Required
- * **proxy**: Required
+ * **userName**: Optional
+ * **password**: Optional
+ * **proxy**: Optional
 
 ### Zip Archive
 
-https://flysystem.thephpleague.com/v1/docs/adapter/zip-archive/
+https://github.com/thephpleague/flysystem-ziparchive
 
-No options
+**Options**
+ * **location**: Path to the archive file
+ * **root**: Root path inside the archive, default ''
+ * **mimeTypeDetector**: Custom mime type detector, default null
+ * **visibility**: Visibility converter, default null
 
 ## Implementing your own Factory
 

--- a/src/Factories/AzureFactory.php
+++ b/src/Factories/AzureFactory.php
@@ -40,20 +40,40 @@ class AzureFactory extends AbstractFactory
     /**
      * @inheritDoc
      */
-    public function build($config): FilesystemAdapter
+    public function build(array $config): FilesystemAdapter
     {
         $this->availabilityCheck();
         $this->checkConfig($config);
 
-        $endpoint = sprintf(
-            $this->endpoint,
-            base64_encode($config['accountName']),
-            base64_encode($config['apiKey']),
+        $client = $this->createBlobService(
+            $this->buildConnectionString($config),
         );
 
-        $client = BlobRestProxy::createBlobService($endpoint);
-
         return new AzureBlobStorageAdapter($client, $config['accountName']);
+    }
+
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @return string
+     */
+    protected function buildConnectionString(array $config): string
+    {
+        return sprintf(
+            $this->endpoint,
+            $config['accountName'],
+            $config['apiKey'],
+        );
+    }
+
+    /**
+     * @param string $connectionString
+     *
+     * @return \MicrosoftAzure\Storage\Blob\BlobRestProxy
+     */
+    protected function createBlobService(string $connectionString): BlobRestProxy
+    {
+        return BlobRestProxy::createBlobService($connectionString);
     }
 
     /**
@@ -66,7 +86,7 @@ class AzureFactory extends AbstractFactory
     protected function checkConfig(array $config): void
     {
         if (empty($config['accountName'])) {
-            throw FactoryConfigException::withMissingKey('apiKey', $this);
+            throw FactoryConfigException::withMissingKey('accountName', $this);
         }
 
         if (empty($config['apiKey'])) {

--- a/src/Factories/DropboxFactory.php
+++ b/src/Factories/DropboxFactory.php
@@ -23,7 +23,7 @@ use Spatie\FlysystemDropbox\DropboxAdapter;
  */
 class DropboxFactory extends AbstractFactory
 {
-    protected string $alias = 'null';
+    protected string $alias = 'dropbox';
 
     protected string $package = 'spatie/flysystem-dropbox';
 
@@ -38,6 +38,7 @@ class DropboxFactory extends AbstractFactory
      */
     public function build(array $config): FilesystemAdapter
     {
+        $this->availabilityCheck();
         $config += $this->defaults;
         $client = new Client($config['authToken']);
 

--- a/src/Factories/MemoryFactory.php
+++ b/src/Factories/MemoryFactory.php
@@ -33,6 +33,8 @@ class MemoryFactory extends AbstractFactory
      */
     public function build(array $config): FilesystemAdapter
     {
+        $this->availabilityCheck();
+
         return new InMemoryFilesystemAdapter();
     }
 }

--- a/src/Factories/WebDavFactory.php
+++ b/src/Factories/WebDavFactory.php
@@ -41,6 +41,9 @@ class WebDavFactory extends AbstractFactory
      */
     public function build(array $config): FilesystemAdapter
     {
+        $this->availabilityCheck();
+        $config += $this->defaults;
+
         return new WebDAVAdapter(new Client($config));
     }
 }

--- a/src/Factories/ZipArchiveFactory.php
+++ b/src/Factories/ZipArchiveFactory.php
@@ -34,6 +34,8 @@ class ZipArchiveFactory extends AbstractFactory
      */
     public function build(array $config): FilesystemAdapter
     {
+        $this->availabilityCheck();
+
         $defaults = [
             'location' => null,
             'root' => '',

--- a/tests/TestCase/Storage/Factories/AzureFactoryTest.php
+++ b/tests/TestCase/Storage/Factories/AzureFactoryTest.php
@@ -16,6 +16,7 @@ namespace PhpCollective\Storage\Test\TestCase\Storage\Factories;
 
 use League\Flysystem\AzureBlobStorage\AzureBlobStorageAdapter;
 use PhpCollective\Infrastructure\Storage\Factories\AzureFactory;
+use PhpCollective\Infrastructure\Storage\Factories\Exception\FactoryConfigException;
 use PhpCollective\Storage\Test\TestCase\StorageTestCase as TestCase;
 
 /**
@@ -28,6 +29,10 @@ class AzureFactoryTest extends TestCase
      */
     public function testFactory(): void
     {
+        if (PHP_VERSION_ID >= 80400) {
+            $this->markTestSkipped('Upstream Azure SDK emits PHP 8.4+ deprecations during adapter creation.');
+        }
+
         $factory = new AzureFactory();
         $adapter = $factory->build([
             'accountName' => 'test',
@@ -35,5 +40,47 @@ class AzureFactoryTest extends TestCase
         ]);
 
         $this->assertInstanceOf(AzureBlobStorageAdapter::class, $adapter);
+    }
+
+    /**
+     * @return void
+     */
+    public function testConnectionStringUsesPlainCredentials(): void
+    {
+        $factory = new class extends AzureFactory {
+            public function buildConnectionStringPublic(array $config): string
+            {
+                return $this->buildConnectionString($config);
+            }
+        };
+
+        $result = $factory->buildConnectionStringPublic([
+            'accountName' => 'test-account',
+            'apiKey' => 'test-key',
+        ]);
+
+        $this->assertSame(
+            'DefaultEndpointsProtocol=https;AccountName=test-account;AccountKey=test-key',
+            $result,
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function testMissingAccountNameExceptionMessage(): void
+    {
+        $factory = new class extends AzureFactory {
+            public function validateConfig(array $config): void
+            {
+                $this->checkConfig($config);
+            }
+        };
+
+        $this->expectException(FactoryConfigException::class);
+        $this->expectExceptionMessage('Config key `accountName`');
+        $factory->validateConfig([
+            'apiKey' => 'test-key',
+        ]);
     }
 }

--- a/tests/TestCase/Storage/Factories/DropboxFactoryTest.php
+++ b/tests/TestCase/Storage/Factories/DropboxFactoryTest.php
@@ -30,6 +30,27 @@ class DropboxFactoryTest extends TestCase
     {
         $factory = new DropboxFactory();
         $adapter = $factory->build([]);
+
+        $this->assertSame('dropbox', $factory->alias());
         $this->assertInstanceOf(DropboxAdapter::class, $adapter);
+    }
+
+    /**
+     * @return void
+     */
+    public function testAvailabilityCheckIsCalled(): void
+    {
+        $factory = new class extends DropboxFactory {
+            public bool $called = false;
+
+            public function availabilityCheck(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $factory->build([]);
+
+        $this->assertTrue($factory->called);
     }
 }

--- a/tests/TestCase/Storage/Factories/MemoryFactoryTest.php
+++ b/tests/TestCase/Storage/Factories/MemoryFactoryTest.php
@@ -32,4 +32,23 @@ class MemoryFactoryTest extends TestCase
         $result = $factory->build([]);
         $this->assertInstanceOf(InMemoryFilesystemAdapter::class, $result);
     }
+
+    /**
+     * @return void
+     */
+    public function testAvailabilityCheckIsCalled(): void
+    {
+        $factory = new class extends MemoryFactory {
+            public bool $called = false;
+
+            public function availabilityCheck(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $factory->build([]);
+
+        $this->assertTrue($factory->called);
+    }
 }

--- a/tests/TestCase/Storage/Factories/WebDavFactoryTest.php
+++ b/tests/TestCase/Storage/Factories/WebDavFactoryTest.php
@@ -34,4 +34,25 @@ class WebDavFactoryTest extends TestCase
         ]);
         $this->assertInstanceOf(WebDAVAdapter::class, $adapter);
     }
+
+    /**
+     * @return void
+     */
+    public function testAvailabilityCheckIsCalled(): void
+    {
+        $factory = new class extends WebDavFactory {
+            public bool $called = false;
+
+            public function availabilityCheck(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $factory->build([
+            'baseUri' => '/',
+        ]);
+
+        $this->assertTrue($factory->called);
+    }
 }

--- a/tests/TestCase/Storage/Factories/ZipArchiveFactoryTest.php
+++ b/tests/TestCase/Storage/Factories/ZipArchiveFactoryTest.php
@@ -37,4 +37,28 @@ class ZipArchiveFactoryTest extends TestCase
         ]);
         $this->assertInstanceOf(ZipArchiveAdapter::class, $adapter);
     }
+
+    /**
+     * @return void
+     */
+    public function testAvailabilityCheckIsCalled(): void
+    {
+        $factory = new class extends ZipArchiveFactory {
+            public bool $called = false;
+
+            public function availabilityCheck(): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $file = $this->tmp . DIRECTORY_SEPARATOR . 'archive-availability.test';
+        touch($file);
+
+        $factory->build([
+            'location' => $file,
+        ]);
+
+        $this->assertTrue($factory->called);
+    }
 }

--- a/tests/TestCase/StorageTestCase.php
+++ b/tests/TestCase/StorageTestCase.php
@@ -29,6 +29,11 @@ class StorageTestCase extends TestCase
     /**
      * @var string
      */
+    protected string $testPath = '';
+
+    /**
+     * @var string
+     */
     protected string $storageRoot = '';
 
     /**


### PR DESCRIPTION
## Summary
- fix adapter factory bugs and inconsistent availability checks across optional adapters
- clean repo metadata/docs so they match the actual Flysystem v3 package and supported factories
- remove self-inflicted PHP 8.4 test deprecations and add regression coverage for Azure config and Dropbox alias behavior

## Notes
- no intended backward compatibility break
- the Azure smoke test is skipped on PHP 8.4+ because the upstream Microsoft Azure SDK currently emits deprecations during adapter construction; our own Azure connection-string and config logic remain covered

## Validation
- `composer test`
- `vendor/bin/phpstan analyze --error-format=raw`
- `composer cs-fix`
- `composer cs-check`